### PR TITLE
Fix life.c stack overflow in nemu

### DIFF
--- a/kernels/demo/src/life/life.c
+++ b/kernels/demo/src/life/life.c
@@ -5,10 +5,11 @@
 #include <io.h>
 
 static int w = 40, h = 25;
+static unsigned **univ = NULL;
+static unsigned **new = NULL;
 
-void show(void *u) {
+void show(void) {
   int x,y;
-  int (*univ)[w] = u;
   screen_clear();
   for (y=0;y<h;y++) {
     for (x=0;x<w;x++)
@@ -17,10 +18,8 @@ void show(void *u) {
   screen_refresh();
 }
 
-void evolve(void *u) {
+void evolve(void) {
   int x,y,x1,y1;
-  unsigned (*univ)[w] = u;
-  unsigned new[h][w];
 
   for (y=0;y<h;y++) for (x=0;x<w;x++) {
     int n = 0;
@@ -40,7 +39,12 @@ void game_of_life(void) {
   h = screen_tile_height();
 
   int x,y;
-  unsigned (*univ)[w] = malloc(h * w * sizeof(unsigned*));
+  univ = malloc(h * sizeof(unsigned int *));
+  new = malloc(h * sizeof(unsigned int *));
+  for (int i = 0; i < h; i++) {
+    univ[i] = malloc(w * sizeof(unsigned int));
+    new[i] = malloc(w * sizeof(unsigned int));
+  }
   for (x=0;x<w;x++)
     for (y=0;y<h;y++) 
       univ[y][x] = rand() % 2;

--- a/kernels/demo/src/life/life.c
+++ b/kernels/demo/src/life/life.c
@@ -38,19 +38,20 @@ void game_of_life(void) {
   w = screen_tile_width();
   h = screen_tile_height();
 
-  int x,y;
-  univ = malloc(h * sizeof(unsigned int *));
-  new = malloc(h * sizeof(unsigned int *));
+  univ = malloc(h * sizeof(unsigned*));
+  new = malloc(h * sizeof(unsigned*));
   for (int i = 0; i < h; i++) {
-    univ[i] = malloc(w * sizeof(unsigned int));
-    new[i] = malloc(w * sizeof(unsigned int));
+    univ[i] = malloc(w * sizeof(unsigned));
+    new[i] = malloc(w * sizeof(unsigned));
   }
+  
+  int x,y;
   for (x=0;x<w;x++)
     for (y=0;y<h;y++) 
       univ[y][x] = rand() % 2;
   while (1) {
-    show(univ);
-    evolve(univ);
+    show();
+    evolve();
     usleep(200000);
   }
 }

--- a/kernels/demo/src/life/life.c
+++ b/kernels/demo/src/life/life.c
@@ -40,7 +40,7 @@ void game_of_life(void) {
   h = screen_tile_height();
 
   int x,y;
-  unsigned univ[h][w];
+  unsigned (*univ)[w] = malloc(h * w * sizeof(unsigned*));
   for (x=0;x<w;x++)
     for (y=0;y<h;y++) 
       univ[y][x] = rand() % 2;


### PR DESCRIPTION
NJU-ProjectN/ics-pa/#issues23
allocate univ in game_of_life() on the heap, so that stack in nemu will not overflow. leave new[h][w] on the stack because of no free() impl