### PR TITLE
[FIX]  am-kernels/kernels/demo/src/hanoi/hanoi.c: pattern not shown on the screen of nemu due to no sync of GPU FB

### DIFF
--- a/kernels/demo/src/hanoi/hanoi.c
+++ b/kernels/demo/src/hanoi/hanoi.c
@@ -31,7 +31,7 @@ static void text(int y, int i, int d, const char *s) {
 static void add_disk(int i, int d) {
   t[i]->x[t[i]->n++] = d;
   text(t[i]->n, i, d, "==");
-
+  screen_refresh();
   usleep(100000);
 }
 


### PR DESCRIPTION
The program cannot show patterns normally on nemu because not  properly refreshing the GPU FB.