### PR TITLE
fix: prevent format error of alu-tests

### DIFF
--- a/tests/alu-tests/gen_alu_test.c
+++ b/tests/alu-tests/gen_alu_test.c
@@ -20,7 +20,7 @@ static const unsigned short vus[]={0x8000, 0x8001, -2, -1, 0, 1, 2, 0x7ffe, 0x7f
 static const unsigned char  vuc[]={0x80, 0x81, -2, -1, 0, 1, 2, 0x7e, 0x7f};
 
 #define TEST_STRING "  printf(\"line %%d: %%s: %%d  %%s  %%d  ==  %%d =>  %%s (%%d)\\n\","\
-                      "__LINE__,\"%s\",%d,\"%s\",%d,%d,(%s)(x%sy)==%d?\"PASS\":\"FAIL\",(%s)(x%sy));\n"
+                      "__LINE__,\"%s\",(int)%d,\"%s\",(int)%d,(int)%d,(%s)(x%sy)==%d?\"PASS\":\"FAIL\",(%s)(x%sy));\n"
 
 #define TEST_STRING_F "  printf(\"%%20s: %%20f  %%2s  %%-20f  ==  %%-20f =>  %%8s (%%f)\\n\","\
                       "\"%s\",%f,\"%s\",%f,%f,(%s)(x%sy)==%f?\"PASS\":\"FAIL\",(%s)(x%sy));\n"


### PR DESCRIPTION
Before change:
```shell
am-kernels/tests/alu-tests/build/alu_test.c:12747:25: error: format '%d' expects argument of type 'int', but argument 4 has type 'long long int' [-Werror=format=]
12747 |   printf("line %d: %s: %d  %s  %d  ==  %d =>  %s (%d)\n",__LINE__,"unsigned int",-2147483648,"||",2,1,(unsigned int)(x||y)==1?"PASS":"FAIL",(unsigned int)(x||y));
```