### PR TITLE
fix: uint32_t overflow in format_time

### DIFF
--- a/benchmarks/microbench/src/bench.c
+++ b/benchmarks/microbench/src/bench.c
@@ -12,7 +12,7 @@ static uint64_t uptime() { return io_read(AM_TIMER_UPTIME).us; }
 
 static char *format_time(uint64_t us) {
   static char buf[32];
-  uint32_t ms = us / 1000;
+  uint64_t ms = us / 1000;
   us -= ms * 1000;
   assert(us < 1000);
   int len = sprintf(buf, "%d.000", ms);


### PR DESCRIPTION
对于Issue #10 的修复